### PR TITLE
Feat add organisation to feed yml

### DIFF
--- a/collectress.py
+++ b/collectress.py
@@ -171,11 +171,11 @@ def should_replace(existing_file, new_content):
     return False
 
 
-def write_to_disk(path, date_str, feed_name, content):
+def write_to_disk(path, date_str, feed_org, feed_name, content):
     """
     Write content to disk as a gzipped file.
     """
-    output_file = os.path.join(path, f"{date_str}_{feed_name}.txt.gz")
+    output_file = os.path.join(path, f"{date_str}_{feed_org}_{feed_name}.txt.gz")
 
     # If the file already exists and should not be replaced, return
     if os.path.exists(output_file) and not should_replace(output_file, content):
@@ -240,7 +240,11 @@ def main(): # pylint: disable=too-many-locals
         # If the download was successful, write the file to disk
         if content is not None:
             total_data_downloaded += len(content)
-            write_to_disk(output_dir, date_str.replace("/", "_"), feed['name'], content)
+            write_to_disk(output_dir,
+                          date_str.replace("/", "_"),
+                          feed['org'],
+                          feed['name'],
+                          content)
             successful_feeds.append(feed['name'])
             total_feeds_success += 1
         else:

--- a/data_feeds_EXAMPLE.yml
+++ b/data_feeds_EXAMPLE.yml
@@ -1,7 +1,10 @@
 feeds:
-  - name: feed_name_1
-    url: http://example.com/feed1
-  - name: feed_name_2
-    url: http://example.com/feed2
-  - name: feed_name_3
-    url: http://example.com/feed3
+  - name: feed_name_1.txt
+    org: feed_1_organisation_name
+    url: http://example.com/feed_name_1.txt
+  - name: feed_name_2.json
+    org: feed_2_organisation_name
+    url: http://example.com/feed_name_2.json
+  - name: feed_name_3.csv
+    org: feed_3_organisation_name
+    url: http://example.com/feed_name_3.csv

--- a/tests/test_collectress.py
+++ b/tests/test_collectress.py
@@ -29,10 +29,10 @@ class TestDirectoryAndFileHandling:
         os.makedirs('temp_dir', exist_ok=True)
 
         # Call the function with test data
-        write_to_disk('temp_dir', 'test_date', 'test_feed', b'test_content')
+        write_to_disk('temp_dir', 'test_date', 'test_org', 'test_feed', b'test_content')
 
         # Assert that the file now exists
-        assert os.path.isfile('temp_dir/test_date_test_feed.txt.gz')
+        assert os.path.isfile('temp_dir/test_date_test_org_test_feed.txt.gz')
 
         # Clean up after the test by removing the directory
         shutil.rmtree('temp_dir')


### PR DESCRIPTION
# Description

Add feed organisation name to output file name. Modifies collectress.py, tests and example feeds.

Fixes #12 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Run pytests locally before PR

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
