### PR TITLE
4 feat add etag file check before downloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,5 +129,8 @@ dmypy.json
 .pyre/
 =======
 *.swp
+
+# Collectress
 data_feeds.yml
 log.json
+etag_cache.json

--- a/collectress.py
+++ b/collectress.py
@@ -243,8 +243,6 @@ def main(): # pylint: disable=too-many-locals
     # Check expired eTags
     remove_old_etags(etag_cache, args.ecache)
 
-    input("Enter your value: ")
-
     # Statistical variables to log
     total_feeds_processed = 0
     total_feeds_not_modified = 0

--- a/collectress.py
+++ b/collectress.py
@@ -22,8 +22,13 @@ from datetime import datetime
 import logging
 import requests
 import yaml
-from lib.etag_cache import load_etag_cache, save_etag_cache, add_to_etag_cache
 from pythonjsonlogger import jsonlogger
+from lib.etag_cache import load_etag_cache
+from lib.etag_cache import add_to_etag_cache
+from lib.etag_cache import remove_from_etag_cache
+from lib.etag_cache import copy_file_from_cache
+from lib.etag_cache import save_etag_cache
+from lib.etag_cache import remove_old_etags
 
 # Create a logger
 logger = logging.getLogger()
@@ -109,33 +114,49 @@ def create_directory(path):
         print(f"Failed to create directory {path} due to {str(err)}")
 
 
-def download_feed(feed_url):
+def download_feed(feed_url, etag_cache):
     """
     Download a feed from a given URL.
 
     This function sends a GET request to the provided URL and returns the response
-    content if the status code is 200. If the status code is not 200, or if an error
-    occurs during the request, the function will print an error message and return None.
+    content, the ETag of the response, and a status code. The status code can be
+    one of the following:
+    - "success": The feed was downloaded successfully.
+    - "not_modified": The feed was not downloaded because the ETag has
+                      not changed since the last download.
+    - "error": There was an error during the download.
 
     Args:
         feed_url (str): The URL of the feed to be downloaded.
+        etag_cache (dict): A dictionary that maps feed URLs to ETags.
 
     Returns:
-        bytes: The content of the response if the request is successful; otherwise, None.
-
-    Raises:
-        Exception: An exception is raised if there's an error during the request,
-                   such as a timeout error or a connection error.
+        tuple: A tuple of three items: the content of the response
+               (or None if the download was not successful or necessary),
+               the ETag of the response (or None if there was an error),
+               and a status code.
     """
+    headers = {}
+    if feed_url in etag_cache:
+        headers['If-None-Match'] = etag_cache[feed_url]['etag']
+
     try:
-        response = requests.get(feed_url)
-        if response.status_code != 200:
-            print(f"Failed to download {feed_url}. Status code: {response.status_code}")
-            return None
-        return response.content
+        response = requests.get(feed_url, headers=headers)
+
+        # If response is 200, file is downloaded and returned
+        if response.status_code == 200:
+            return response.content, response.headers.get('ETag'), "success"
+
+        # If response is 304, file is not downloaded
+        if response.status_code == 304:
+            return None, None, "not_modified"
+
+        # Any other case is considered failure and error is returned
+        print(f"Failed to download {feed_url}. Status code: {response.status_code}")
+        return None, None, "error"
     except requests.RequestException as err:
         print(f"Failed to download {feed_url} due to {str(err)}")
-        return None
+        return None, None, "error"
 
 
 def should_replace(existing_file, new_content):
@@ -219,13 +240,20 @@ def main(): # pylint: disable=too-many-locals
     # Load etag cache from disk
     etag_cache = load_etag_cache(args.ecache)
 
+    # Check expired eTags
+    remove_old_etags(etag_cache, args.ecache)
+
+    input("Enter your value: ")
+
     # Statistical variables to log
     total_feeds_processed = 0
+    total_feeds_not_modified = 0
     total_feeds_success = 0
     total_feeds_failed = 0
     total_data_downloaded = 0
     total_runtime = 0
     successful_feeds = []
+    not_modified_feeds = []
     failed_feeds = []
     success_rate = 0
     error_rate = 0
@@ -241,25 +269,47 @@ def main(): # pylint: disable=too-many-locals
         create_directory(output_dir)
 
         # Download the file from feed's url
-        content, etag = download_feed(feed['url'], etag_cache)
+        content, etag, status = download_feed(feed['url'], etag_cache)
 
         # If the download was successful, write the file to disk
-        if content is not None:
-            total_data_downloaded += len(content)
+        if status == "success":
+            # Store the ETag in the cache
+            add_to_etag_cache(etag_cache, etag, feed['url'], feed['name'], feed['org'])
+
+            # Save the content to disk
             write_to_disk(output_dir,
                           date_str.replace("/", "_"),
                           feed['org'],
                           feed['name'],
                           content)
+
+            # Record metrics
+            total_data_downloaded += len(content)
             successful_feeds.append(feed['name'])
             total_feeds_success += 1
+        elif status == "not_modified":
+            # The file has not changed since yesterday
+            # Copy file from yesterday to today
+            if copy_file_from_cache(root_dir, feed):
+                # Record metrics
+                not_modified_feeds.append(feed['name'])
+                total_feeds_not_modified += 1
+            else:
+                print("copy_file_from_cache: failed")
+                # The file download failed, remove etag from cache
+                remove_from_etag_cache(feed['url'], etag_cache)
+                # Record metrics
+                total_feeds_failed += 1
+                failed_feeds.append(feed['name'])
+
         else:
+            # The file download failed
             total_feeds_failed += 1
             failed_feeds.append(feed['name'])
 
     # Calculate success and error rates
     if total_feeds_processed > 0:
-        success_rate = (total_feeds_success / total_feeds_processed) * 100
+        success_rate = ((total_feeds_success+total_feeds_not_modified)/total_feeds_processed) * 100
         error_rate = (total_feeds_failed / total_feeds_processed) * 100
 
 
@@ -276,10 +326,12 @@ def main(): # pylint: disable=too-many-locals
         'message': f"{date_str.replace('/', '-')} collectress download summary",
         'timestamp': datetime.now().isoformat(),
         'total_feeds_processed': total_feeds_processed,
+        'total_feeds_not_modified': total_feeds_not_modified,
         'total_feeds_success': total_feeds_success,
         'total_feeds_failed': total_feeds_failed,
-        'successful_feeds': successful_feeds,
-        'failed_feeds': failed_feeds,
+        'feeds_not_modified': not_modified_feeds,
+        'feeds_successful': successful_feeds,
+        'feeds_failed': failed_feeds,
         'total_data_downloaded_bytes': total_data_downloaded,
         'total_runtime_seconds': total_runtime,
         'success_rate': success_rate,

--- a/lib/etag_cache.py
+++ b/lib/etag_cache.py
@@ -1,0 +1,170 @@
+"""
+Utility functions for the Collectress tool.
+
+This module contains functions for managing the ETag cache used by the Collectress tool,
+which is responsible for downloading data feeds.
+
+Functions:
+    load_etag_cache: Load the ETag cache from a JSON file at the specified path.
+    save_etag_cache: Save the ETag cache to a JSON file at the specified path.
+    add_to_etag_cache: Add an ETag and associated feed information to the ETag cache.
+Each function is documented individually below.
+"""
+
+import json
+import os
+import shutil
+from datetime import datetime
+from datetime import timedelta
+
+def add_to_etag_cache(etag_cache, etag, feed_url, feed_name, feed_organization):
+    """
+    Adds an ETag and associated feed information to the ETag cache.
+
+    Args:
+        etag_cache (dict): The ETag cache.
+        etag (str): The ETag.
+        feed_url (str): The URL of the feed.
+        feed_name (str): The name of the feed.
+        feed_organization (str): The organization that provides the feed.
+
+    Returns:
+        None. The ETag cache is updated in-place.
+    """
+    download_date = datetime.now().isoformat()
+
+    etag_cache[feed_url] = {
+        "etag": etag,
+        "feed_name": feed_name,
+        "feed_organization": feed_organization,
+        "download_date": download_date
+    }
+
+
+def remove_from_etag_cache(feed_url, etag_cache):
+    """
+    Removes an ETag and associated feed information from the ETag cache.
+
+    Args:
+        feed_url (str): The URL of the feed.
+        etag_cache (dict): The ETag cache.
+
+    Returns:
+        None. The ETag cache is updated in-place.
+    """
+    if feed_url in etag_cache:
+        del etag_cache[feed_url]
+
+
+def load_etag_cache(etag_cache_file):
+    """
+    Load the ETag cache from a file.
+
+    Args:
+        etag_cache_file (str): The path to the ETag cache file.
+
+    Returns:
+        dict: The ETag cache. If an error occurs while reading the file,
+              or if the file does not exist, return an empty dictionary.
+    """
+    try:
+        with open(etag_cache_file, 'r', encoding='utf-8') as file:
+            return json.load(file)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def save_etag_cache(etag_cache_file, etag_cache):
+    """
+    Save the ETag cache to a file.
+
+    Args:
+        etag_cache_file (str): The path to the ETag cache file.
+        etag_cache (dict): The ETag cache to be saved.
+
+    Raises:
+        IOError: An error occurred while writing the ETag cache to the file.
+    """
+    try:
+        with open(etag_cache_file, 'w', encoding='utf-8') as file:
+            json.dump(etag_cache, file)
+    except IOError as err:
+        print(f"An error occurred writing the ETag cache to the file {etag_cache_file}: {err}")
+
+def copy_file_from_cache(root_dir, feed):
+    """
+    If there was a cache hit, this function Copies the file from
+    yesterday's directory to today's directory.
+
+    Args:
+        root_dir (str): The root directory where files are stored.
+        output_dir (str): The output directory for today.
+        feed (dict): The feed information.
+
+    Returns:
+        bool: True if the file was successfully copied, False otherwise.
+    """
+    yesterday_date_str = (datetime.now() - timedelta(days=1)).strftime("%Y/%m/%d")
+    today_date_str = (datetime.now()).strftime("%Y/%m/%d")
+
+    yesterday_file_path = os.path.join(root_dir,
+            yesterday_date_str,
+            f"{yesterday_date_str.replace('/', '_')}_{feed['org']}_{feed['name']}.txt.gz")
+
+    today_file_path = os.path.join(root_dir,
+            today_date_str,
+            f"{today_date_str.replace('/', '_')}_{feed['org']}_{feed['name']}.txt.gz")
+
+    # Check if yesterday's file exists
+    # If yesterday file is not there, do not copy
+    if not os.path.isfile(yesterday_file_path):
+        return False
+
+    # Check if today's file exists
+    # If today file is already there, do not copy
+    # considering that content was not_modified
+    if os.path.isfile(today_file_path):
+        return True
+
+    # Copy the file
+    try:
+        shutil.copy2(yesterday_file_path, today_file_path)
+    except IOError:
+        return False
+
+    return True
+
+
+def remove_old_etags(etag_cache, cache_file_path):
+    """
+    Removes ETags that are older than 24 hours from the ETag cache.
+
+    Args:
+        etag_cache (dict): The ETag cache.
+        cache_file_path (str): The path to the ETag cache file.
+
+    Returns:
+        None. The ETag cache is updated in-place.
+    """
+    # Get the current date and time
+    now = datetime.now()
+
+    # Initialize a list to store the feed URLs of old ETags
+    old_etags = []
+
+    # Iterate over the ETag cache
+    for feed_url, etag_info in etag_cache.items():
+        # Parse the download date of the ETag as a datetime object
+        download_date = datetime.fromisoformat(etag_info['download_date'])
+
+        # If the ETag is older than 24 hours, add its feed URL to the list of old ETags
+        if now - download_date > timedelta(hours=24):
+            old_etags.append(feed_url)
+
+    # Remove the old ETags from the cache
+    for feed_url in old_etags:
+        etag_cache.pop(feed_url)
+
+    # Save the updated ETag cache
+    with open(cache_file_path, 'w', encoding='utf-8') as file:
+        json.dump(etag_cache, file)

--- a/tests/test_etag_cache.py
+++ b/tests/test_etag_cache.py
@@ -1,0 +1,41 @@
+# pylint: disable=missing-docstring
+import json
+import sys
+import tempfile
+from os import path
+sys.path.append( path.dirname(path.dirname( path.abspath(__file__) ) ))
+from lib.etag_cache import load_etag_cache
+from lib.etag_cache import add_to_etag_cache
+from lib.etag_cache import remove_from_etag_cache
+from lib.etag_cache import copy_file_from_cache
+from lib.etag_cache import save_etag_cache
+from lib.etag_cache import remove_old_etags
+
+
+class TestEtagCache:
+    def test_load_etag_cache(self):
+        # Prepare a dictionary with ETag cache data
+        etag_data = {
+            "https://example.com/feed1.xml": {
+                "etag": "\"33a64df551425fcc55e4d42a148795d9f25f89d4\"",
+                "feed_name": "Feed 1",
+                "feed_organization": "Organization 1",
+                "download_date": "2023-07-21T14:30:16.123456"
+            },
+            "https://example.com/feed2.xml": {
+                "etag": "\"58e6b3a414a1e090dfc6029add0f3555ccba172f\"",
+                "feed_name": "Feed 2",
+                "feed_organization": "Organization 2",
+                "download_date": "2023-07-21T14:35:42.654321"
+            }
+        }
+
+        # Create a temporary file and write the ETag cache data into it
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmpfile:
+            json.dump(etag_data, tmpfile)
+
+        # Load the ETag cache using the function under test
+        loaded_etag_data = load_etag_cache(tmpfile.name)
+
+        # Assert that the loaded data matches the original data
+        assert loaded_etag_data == etag_data

--- a/tests/test_etag_cache.py
+++ b/tests/test_etag_cache.py
@@ -4,6 +4,8 @@ import sys
 import tempfile
 from os import path
 from unittest.mock import ANY
+from unittest.mock import patch
+from unittest.mock import mock_open
 sys.path.append( path.dirname(path.dirname( path.abspath(__file__) ) ))
 from lib.etag_cache import load_etag_cache
 from lib.etag_cache import add_to_etag_cache
@@ -109,3 +111,26 @@ class TestEtagCache:
             "feed_organization": "Organization 2",
             "download_date": ANY  # We can't know the exact datetime
         }
+
+
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('json.dump')
+    def test_save_etag_cache(self, mock_json_dump, mock_file):
+        # Create a sample etag_cache dictionary
+        etag_cache = {
+            "https://dummyurl.com/feed1.xml": {
+                "etag": "etag1",
+                "feed_name": "Feed 1",
+                "feed_organization": "Organization 1",
+                "download_date": "2023-07-21T14:30:16.123456"
+            }
+        }
+
+        # Call the function to save the etag cache
+        save_etag_cache("etag_cache.json", etag_cache)
+
+        # Assert that the function correctly called the built-in open function
+        mock_file.assert_called_once_with("etag_cache.json", 'w', encoding='utf-8')
+
+        # Assert that the function correctly called json.dump with the correct arguments
+        mock_json_dump.assert_called_once_with(etag_cache, mock_file())

--- a/tests/test_etag_cache.py
+++ b/tests/test_etag_cache.py
@@ -101,7 +101,11 @@ class TestEtagCache:
         }
 
         # Call the function to add an etag to the cache
-        add_to_etag_cache(etag_cache, "etag2", "https://dummyurl.com/feed2.xml", "Feed 2", "Organization 2")
+        add_to_etag_cache(etag_cache,
+                          "etag2",
+                          "https://dummyurl.com/feed2.xml",
+                          "Feed 2",
+                          "Organization 2")
 
         # Assert that the etag has been added to the cache
         assert "https://dummyurl.com/feed2.xml" in etag_cache

--- a/tests/test_etag_cache.py
+++ b/tests/test_etag_cache.py
@@ -3,6 +3,7 @@ import json
 import sys
 import tempfile
 from os import path
+from unittest.mock import ANY
 sys.path.append( path.dirname(path.dirname( path.abspath(__file__) ) ))
 from lib.etag_cache import load_etag_cache
 from lib.etag_cache import add_to_etag_cache
@@ -85,3 +86,26 @@ class TestEtagCache:
 
         # Assert that the cache has not been modified
         assert len(etag_cache) == 2
+
+    def test_add_to_etag_cache(self):
+        # Create a sample etag_cache dictionary
+        etag_cache = {
+            "https://dummyurl.com/feed1.xml": {
+                "etag": "etag1",
+                "feed_name": "Feed 1",
+                "feed_organization": "Organization 1",
+                "download_date": "2023-07-21T14:30:16.123456"
+            }
+        }
+
+        # Call the function to add an etag to the cache
+        add_to_etag_cache(etag_cache, "etag2", "https://dummyurl.com/feed2.xml", "Feed 2", "Organization 2")
+
+        # Assert that the etag has been added to the cache
+        assert "https://dummyurl.com/feed2.xml" in etag_cache
+        assert etag_cache["https://dummyurl.com/feed2.xml"] == {
+            "etag": "etag2",
+            "feed_name": "Feed 2",
+            "feed_organization": "Organization 2",
+            "download_date": ANY  # We can't know the exact datetime
+        }

--- a/tests/test_etag_cache.py
+++ b/tests/test_etag_cache.py
@@ -39,3 +39,49 @@ class TestEtagCache:
 
         # Assert that the loaded data matches the original data
         assert loaded_etag_data == etag_data
+
+    def test_remove_from_etag_cache(self):
+        # Create a sample etag_cache dictionary
+        etag_cache = {
+            "https://dummyurl.com/feed1.xml": {
+                "etag": "etag1",
+                "feed_name": "Feed 1",
+                "feed_organization": "Organization 1",
+                "download_date": "2023-07-21T14:30:16.123456"
+            },
+            "https://dummyurl.com/feed2.xml": {
+                "etag": "etag2",
+                "feed_name": "Feed 2",
+                "feed_organization": "Organization 2",
+                "download_date": "2023-07-21T14:35:42.654321"
+            }
+        }
+
+        # Call the function to remove an etag from the cache
+        remove_from_etag_cache("https://dummyurl.com/feed1.xml", etag_cache)
+
+        # Assert that the etag has been removed from the cache
+        assert "https://dummyurl.com/feed1.xml" not in etag_cache
+
+    def test_remove_nonexistent_from_etag_cache(self):
+        # Create a sample etag_cache dictionary
+        etag_cache = {
+            "https://dummyurl.com/feed1.xml": {
+                "etag": "etag1",
+                "feed_name": "Feed 1",
+                "feed_organization": "Organization 1",
+                "download_date": "2023-07-21T14:30:16.123456"
+            },
+            "https://dummyurl.com/feed2.xml": {
+                "etag": "etag2",
+                "feed_name": "Feed 2",
+                "feed_organization": "Organization 2",
+                "download_date": "2023-07-21T14:35:42.654321"
+            }
+        }
+
+        # Call the function to remove an etag that does not exist in the cache
+        remove_from_etag_cache("https://nonexistenturl.com/feed3.xml", etag_cache)
+
+        # Assert that the cache has not been modified
+        assert len(etag_cache) == 2


### PR DESCRIPTION
# Description

This PR includes the implementation of an ETag cache for feed downloads. The cache stores the ETags of downloaded feeds and their corresponding download times.
- When a feed is to be downloaded, the cache is checked for a matching ETag.
- If a match is found and it's less than 24 hours old, the feed should not be downloaded again.
- This functionality optimizes network usage and minimizes unnecessary downloads.
- The ETag cache is saved to a file after each feed download and is loaded from this file when the script starts.
- This PR also includes functions for adding and removing entries from the cache, as well as a function to remove ETags that are more than 24 hours old.

This PR does not introduce any breaking changes and does not require any new dependencies.

Fixes #4 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The changes have been tested with tests for each new function:

- Loading the ETag cache from a file.
- Saving the ETag cache to a file.
- Adding an ETag to the cache.
- Removing an ETag from the cache.
- Removing old ETags that are more than 24 hours old.


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
